### PR TITLE
Patch crystal 0 19 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Crystal-lang bindings for [libui](https://github.com/andlabs/libui), a GUI libra
 ![OS X](https://raw.githubusercontent.com/andlabs/libui/master/examples/controlgallery/darwin.png)
 
 ## What's New
-
+11/09/16
+- patch for crystal version 0.19.4 (fixes for syntax 'as')
 08/13/16
 - Sync'd to upstream #6e45859
 - Control Gallery not updated, but yml examples were

--- a/src/examples/crgallery/crgallery.cr
+++ b/src/examples/crgallery/crgallery.cr
@@ -21,7 +21,7 @@ class CRGallery
     # appropriate component (retrieved using its name)
     # ----------------------------------------------------------------------------
     top_components = CUI.inflate "src/examples/crgallery/main.yml"
-    container = CUI.get!("contains_children") as UI::Box*
+    container = CUI.get!("contains_children").as UI::Box*
 
     # ----------------------------------------------------------------------------
     # This file describes basic controls. No fancy bindings here.
@@ -106,20 +106,20 @@ class CRGallery
       nil
 
     UI.spinbox_on_changed \
-      CUI.get!("spinbox") as UI::Spinbox*,
+      CUI.get!("spinbox").as UI::Spinbox*,
       ->(s: UI::Spinbox*, data: Void*) {
-        value = UI.spinbox_value CUI.get!("spinbox") as UI::Spinbox*
-        UI.slider_set_value CUI.get!("slider") as UI::Slider*, value
-        UI.progress_bar_set_value CUI.get!("progress_bar") as UI::ProgressBar*, value
+        value = UI.spinbox_value CUI.get!("spinbox").as UI::Spinbox*
+        UI.slider_set_value CUI.get!("slider").as UI::Slider*, value
+        UI.progress_bar_set_value CUI.get!("progress_bar").as UI::ProgressBar*, value
       },
       nil
 
     UI.slider_on_changed \
-      CUI.get!("slider") as UI::Slider*,
+      CUI.get!("slider").as UI::Slider*,
       ->(s: UI::Slider*, data: Void*) {
-        value = UI.slider_value CUI.get!("slider") as UI::Slider*
-        UI.spinbox_set_value CUI.get!("spinbox") as UI::Spinbox*, value
-        UI.progress_bar_set_value CUI.get!("progress_bar") as UI::ProgressBar*, value
+        value = UI.slider_value CUI.get!("slider").as UI::Slider*
+        UI.spinbox_set_value CUI.get!("spinbox").as UI::Spinbox*, value
+        UI.progress_bar_set_value CUI.get!("progress_bar").as UI::ProgressBar*, value
       },
       nil
 

--- a/src/libui/cui.cr
+++ b/src/libui/cui.cr
@@ -55,21 +55,21 @@ module CUI extend self
   def get_as_menuitem(name : String) : UI::MenuItem* | Nil
     m = get name
     return nil if m.is_a?(Nil)
-    m as UI::MenuItem*
+    m.as UI::MenuItem*
   end
 
   def get_as_menuitem!(name : String) : UI::MenuItem*
-    (get! name) as UI::MenuItem*
+    (get! name).as UI::MenuItem*
   end
 
   def get_mainwindow : UI::Window* | Nil
     m = get "sys::mainwindow"
     return nil if m.is_a?(Nil)
-    m as UI::Window*
+    m.as UI::Window*
   end
 
   def get_mainwindow! : UI::Window*
-    (get! "sys::mainwindow") as UI::Window*
+    (get! "sys::mainwindow").as UI::Window*
   end
 
   # ----------------------------------------------------------------------------
@@ -174,12 +174,13 @@ module CUI extend self
 
     case type
     when "window"
-      UI.window_set_child parent as UI::Window*, child
+      UI.window_set_child parent.as UI::Window*, child
     when "vertical_box", "horizontal_box"
       # TODO stretchy instead of 0
-      UI.box_append parent as UI::Box*, child, stretched
+      UI.box_append parent.as UI::Box*, child, stretched
     when "group"
-      UI.group_set_child parent as UI::Group*, child
+      # UI.group_set_child parent as UI::Group*, child
+      UI.group_set_child(parent.as UI::Group*, child)
     else
       puts "## Warning: unknown child type ###"
     end
@@ -188,11 +189,11 @@ module CUI extend self
   private def add_item(type, parent : UI::Control*, attributes, item)
     case type
     when "combobox"
-      UI.combobox_append parent as UI::Combobox*, item
+      UI.combobox_append(parent.as UI::Combobox*, item)
     when "editable_combobox"
-      UI.editable_combobox_append parent as UI::EditableCombobox*, item
+      UI.editable_combobox_append(parent.as UI::EditableCombobox*, item)
     when "radio_buttons"
-      UI.radio_buttons_append parent as UI::RadioButtons*, item
+      UI.radio_buttons_append(parent.as UI::RadioButtons*, item)
     else
       puts "## Warning: unknown item type ###"
     end
@@ -335,9 +336,9 @@ module CUI extend self
     unless menu.is_a?(Nil)
       unless children.nil?
         children.each do |child|
-          name = child[0] as String
-          text = child[1] as String
-          desc = child[2] as Int32
+          name = child[0].as String
+          text = child[1].as String
+          desc = child[2].as Int32
           if (desc & MenuDesc::Check.value != 0)
             item = UI.menu_append_check_item menu, text
           elsif (desc & MenuDesc::Quit.value != 0)

--- a/src/libui/libui.cr
+++ b/src/libui/libui.cr
@@ -324,11 +324,11 @@ end
 # Some Sugar
 
 macro ui_control(control)
-  {{control}} as UI::Control*
+  {{control}}.as UI::Control*
 end
 
 macro ui_box(control)
-  {{control}} as UI::Box*
+  {{control}}.as UI::Box*
 end
 
 macro ui_nil?(ptr)


### PR DESCRIPTION
- patch for crystal version 0.19.4 (fixes for syntax 'as')