### PR TITLE
Add UI.main_steps & UI.timer for using libui in a spawn.

### DIFF
--- a/src/libui/libui.cr
+++ b/src/libui/libui.cr
@@ -95,12 +95,14 @@ lib UI
   # Life Cycle
 
   fun main = uiMain
+  fun main_steps = uiMainSteps() : Void
   fun main_step = uiMainStep(wait : LibC::Int) : LibC::Int
   fun init = uiInit(options : UI::InitOptions*) : Char*
   fun uninit = uiUninit
   fun quit = uiQuit
   fun free_text = uiFreeText(text : UInt8*)
   fun free_init_error = uiFreeInitError(err : UInt8*)
+  fun timer = uiTimer(milliseconds : LibC::Int, f : Void* ->, data : Void*) : Void
 
   # Components
 


### PR DESCRIPTION
## UI.main_steps()
`UI.main_step(wait)` needs `UI.main_steps()` before it's called. If don't, it causes a memory error. We should use this like following : 

```crystal
UI.main_steps()
while UI.main_step(1) != 0
  # Some codes.
end
```

## UI.timer(milliseconds, f, data)
I'm creating a Crystal app that has 2 event loops, libui & HTTPServer. I put them into `spawn`, then the HTTPServer works fine. But libui C part holds the Crystal scheduler & never leaves its control. Once `UI.main()` was called it never back to Crystal event loop (except libui's own events).
One solution is `UI.main_steps()`. This works more, but it only back to Crystal event loop when the UI is foreground. When the UI is background, `UI.main_step(wait)` never returns.

`uiTimer(milliseconds, f, data)` is the solution, so I want this.

```crystal
spawn do
  UI.timer 1, ->(_data) { sleep Time::Span(nanoseconds: 1000) }, nil
  UI.main
  UI.uninit
end
```